### PR TITLE
feat(docker): Pin debian distro name to base images, RES-338

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13.9-slim@sha256:326df678c20c78d465db501563f3492d17c42a4afe33a1f2bf5406a1d56b0e86 AS base
+FROM python:3.13.9-slim-bookworm@sha256:326df678c20c78d465db501563f3492d17c42a4afe33a1f2bf5406a1d56b0e86 AS base
 COPY --from=ghcr.io/astral-sh/uv:0.9.13@sha256:f07d1bf7b1fb4b983eed2b31320e25a2a76625bdf83d5ff0208fe105d4d8d2f5 /uv /uvx /bin/
 
 WORKDIR /app
@@ -32,7 +32,7 @@ USER strg
 
 RUN uv sync --frozen --no-dev
 
-FROM python:3.13.9-slim@sha256:326df678c20c78d465db501563f3492d17c42a4afe33a1f2bf5406a1d56b0e86 AS production
+FROM python:3.13.9-slim-bookworm@sha256:326df678c20c78d465db501563f3492d17c42a4afe33a1f2bf5406a1d56b0e86 AS production
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13.9-slim-bookworm@sha256:326df678c20c78d465db501563f3492d17c42a4afe33a1f2bf5406a1d56b0e86 AS base
+FROM python:3.13.9-slim-trixie@sha256:326df678c20c78d465db501563f3492d17c42a4afe33a1f2bf5406a1d56b0e86 AS base
 COPY --from=ghcr.io/astral-sh/uv:0.9.13@sha256:f07d1bf7b1fb4b983eed2b31320e25a2a76625bdf83d5ff0208fe105d4d8d2f5 /uv /uvx /bin/
 
 WORKDIR /app
@@ -32,7 +32,7 @@ USER strg
 
 RUN uv sync --frozen --no-dev
 
-FROM python:3.13.9-slim-bookworm@sha256:326df678c20c78d465db501563f3492d17c42a4afe33a1f2bf5406a1d56b0e86 AS production
+FROM python:3.13.9-slim-trixie@sha256:326df678c20c78d465db501563f3492d17c42a4afe33a1f2bf5406a1d56b0e86 AS production
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,18 +3,18 @@ COPY --from=ghcr.io/astral-sh/uv:0.9.13@sha256:f07d1bf7b1fb4b983eed2b31320e25a2a
 
 WORKDIR /app
 
+COPY . .
+
 RUN useradd -m strg && \
     chown -R strg:strg /app
-
-USER strg
-
-COPY . .
 
 ENV PATH="/app/.venv/bin:$PATH"
 ENV UV_COMPILE_BYTECODE=1
 ENV UV_LINK_MODE="copy"
 ENV UV_NO_CACHE=1
 ENV PYTHONUNBUFFERED=1
+
+USER strg
 
 RUN uv sync --dev --frozen
 
@@ -36,13 +36,13 @@ FROM python:3.13.9-slim-trixie@sha256:326df678c20c78d465db501563f3492d17c42a4afe
 
 WORKDIR /app
 
+COPY --from=build /app/.venv ./.venv
+COPY . .
+
 RUN useradd -m strg && \
     chown -R strg:strg /app
 
 USER strg
-
-COPY --from=build /app/.venv ./.venv
-COPY . .
 
 ENV PATH="/app/.venv/bin:$PATH"
 ENV PYTHONUNBUFFERED=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,13 @@ COPY . .
 RUN useradd -m strg && \
     chown -R strg:strg /app
 
+USER strg
+
 ENV PATH="/app/.venv/bin:$PATH"
 ENV UV_COMPILE_BYTECODE=1
 ENV UV_LINK_MODE="copy"
 ENV UV_NO_CACHE=1
 ENV PYTHONUNBUFFERED=1
-
-USER strg
 
 RUN uv sync --dev --frozen
 


### PR DESCRIPTION
Pinning the distro name is important imo since there are also changes in apt packages availability from one distro version to another